### PR TITLE
fix optional parameters check in harp.compile()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -160,7 +160,7 @@ exports.compile = function(projectPath, outputPath, callback){
    * Both projectPath and outputPath are optional
    */
 
-  if(!callback){
+  if(!callback && typeof outputPath === "function"){
     callback   = outputPath
     outputPath = "www"
   }


### PR DESCRIPTION
Code was assuming that if calling `harp.compile(projectPath [,outputPath] [, callback])` with two parameters, the second is always a callback. 

fixes #391